### PR TITLE
Fix flicker on flip cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -347,6 +347,9 @@ button,
 
 .flip-card {
 	perspective: 1000px;
+	backface-visibility: hidden;
+	transform-style: preserve-3d;
+	will-change: transform;
 }
 
 .flip-inner {


### PR DESCRIPTION
## Summary
- stop flicker by stabilizing the flip card transform

## Testing
- `npm run check`
